### PR TITLE
Remove lodash and move to lodash modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,11 @@
   },
   "homepage": "https://github.com/workstreams-ai/slack-block-kit#readme",
   "dependencies": {
-    "lodash": "^4.17.11"
+    "lodash.isobject": "^3.0.2",
+    "lodash.isstring": "^4.0.1",
+    "lodash.isundefined": "^3.0.1",
+    "lodash.omit": "^4.5.0",
+    "lodash.omitby": "^4.6.0"
   },
   "devDependencies": {
     "babel-cli": "^6.22.2",

--- a/src/block.js
+++ b/src/block.js
@@ -1,6 +1,7 @@
-import {
-  isObject, omit, omitBy, isUndefined,
-} from 'lodash'
+import isObject from 'lodash.isobject'
+import omit from 'lodash.omit'
+import omitBy from 'lodash.omitby'
+import isUndefined from 'lodash.isundefined'
 
 import object, {
   TEXT_FORMAT_MRKDWN, TEXT_FORMAT_PLAIN,

--- a/src/element.js
+++ b/src/element.js
@@ -1,6 +1,8 @@
-import {
-  omitBy, omit, isUndefined, isString,
-} from 'lodash'
+import omit from 'lodash.omit'
+import omitBy from 'lodash.omitby'
+import isString from 'lodash.isstring'
+import isUndefined from 'lodash.isundefined'
+
 import basicObject from './object'
 
 const { text } = basicObject

--- a/src/object.js
+++ b/src/object.js
@@ -1,4 +1,7 @@
-import { omitBy, isUndefined, isString } from 'lodash'
+import omitBy from 'lodash.omitby'
+import isUndefined from 'lodash.isundefined'
+import isString from 'lodash.isstring'
+
 // text formats
 const TEXT_FORMAT_PLAIN = 'plain_text'
 const TEXT_FORMAT_MRKDWN = 'mrkdwn'
@@ -35,7 +38,7 @@ const text = (textValue, formatting = TEXT_FORMAT_PLAIN, { emoji, verbatim } = {
   if (!isUndefined(emoji) && typeof emoji !== 'boolean') {
     throw new ObjectError('Emoji has to be boolean')
   }
-  
+
   if (!isUndefined(verbatim) && typeof verbatim !== 'boolean') {
     throw new ObjectError('Verbatim has to be boolean')
   }


### PR DESCRIPTION
Hello all,

This is a great package that I'm eager to use in production, though it's a little too weighty to use with lambdas at the moment.

Lodash accounts for over 90% of the package size, so I've pulled out the main dependency and opted for lodash modules instead.

Passes tests.