### PR TITLE
Bundle only required files

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "clean": "rm -rf dist",
     "build": "npm run clean && ./node_modules/.bin/babel -d dist src",
     "test": "./node_modules/.bin/babel-node ./node_modules/.bin/_mocha test/*-test.js",
-    "coverage": "nyc npm run test"
+    "coverage": "nyc npm run test",
+    "prepublishOnly": "npm run coverage && npm run build"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.9.2",
   "description": "",
   "main": "dist/index.js",
+  "files": [
+    "/dist"
+  ],
   "scripts": {
     "clean": "rm -rf dist",
     "build": "npm run clean && ./node_modules/.bin/babel -d dist src",


### PR DESCRIPTION
This PR ensures only the exported module is bundled in the NPM package, which reduces the package size to 5.9kB.

I've also added a pre-publish script that runs test coverage and builds `dist` to prevent accidents.